### PR TITLE
fix: correctly convert JWP capabilities to W3C

### DIFF
--- a/src/process-config.ts
+++ b/src/process-config.ts
@@ -57,7 +57,7 @@ export function processConfig(config: any = {}, args: any = {}) {
   };
 
   // transform JWP capabilities into W3C capabilities for backward compatibility
-  if (isW3C(args)) {
+  if (!isW3C(args)) {
     args.browserVersion = args.browserVersion || args.version || 'latest'
     args.platformName = args.platformName || args.platform || 'Windows 10'
     args['sauce:options'] = {...capabilitiesFromConfig, ...(args['sauce:options'] || {})}


### PR DESCRIPTION
The `processConfig()` function attempts to convert capabilities from the deprecated JWP format to the new standard W3C one.

Fix the logic for detecting when capabilites are in JWP format. (Previously, the logic was inverted.)